### PR TITLE
Fix note hitboxes on small notes

### DIFF
--- a/include/CustomTypes/BasicNoteScaler.hpp
+++ b/include/CustomTypes/BasicNoteScaler.hpp
@@ -15,6 +15,7 @@
 
 DECLARE_CLASS_CODEGEN_INTERFACES(Qosmetics::Notes, BasicNoteScaler, UnityEngine::MonoBehaviour, classof(GlobalNamespace::INoteControllerDidInitEvent*),
                                  DECLARE_INSTANCE_PRIVATE_FIELD(GlobalNamespace::NoteControllerBase*, noteController);
+                                 DECLARE_INSTANCE_FIELD(float, notesUniformScale);
                                  DECLARE_INSTANCE_METHOD(void, Awake);
                                  DECLARE_INSTANCE_METHOD(void, OnDestroy);
                                  DECLARE_INSTANCE_METHOD(GlobalNamespace::INoteControllerDidInitEvent*, i_INoteControllerDidInitEvent);

--- a/src/CustomTypes/BasicNoteScaler.cpp
+++ b/src/CustomTypes/BasicNoteScaler.cpp
@@ -25,6 +25,6 @@ namespace Qosmetics::Notes
 
     void BasicNoteScaler::HandleNoteControllerDidInit(GlobalNamespace::NoteControllerBase* noteController)
     {
-        get_transform()->set_localScale(Sombrero::FastVector3::one() * Config::get_config().noteSize);
+        get_transform()->set_localScale(Sombrero::FastVector3::one() * Config::get_config().noteSize * notesUniformScale);
     }
 }

--- a/src/Installers/GameInstaller.cpp
+++ b/src/Installers/GameInstaller.cpp
@@ -204,7 +204,8 @@ namespace Qosmetics::Notes
 
         if (globalConfig.get_overrideNoteSize())
         {
-            noteCubeTransform->get_gameObject()->AddComponent<Qosmetics::Notes::BasicNoteScaler*>();
+            auto noteScaler = noteCubeTransform->get_gameObject()->AddComponent<Qosmetics::Notes::BasicNoteScaler*>();
+            noteScaler->notesUniformScale = _gameplayCoreSceneSetupData->gameplayModifiers->get_notesUniformScale();
 
             // if we don't want to change hitbox sizes, scale the cuttable hitboxes to make them proper size
             if (!globalConfig.get_alsoChangeHitboxes())
@@ -321,7 +322,8 @@ namespace Qosmetics::Notes
 
         if (globalConfig.get_overrideNoteSize())
         {
-            noteCubeTransform->get_gameObject()->AddComponent<Qosmetics::Notes::BasicNoteScaler*>();
+            auto noteScaler = noteCubeTransform->get_gameObject()->AddComponent<Qosmetics::Notes::BasicNoteScaler*>();
+            noteScaler->notesUniformScale = _gameplayCoreSceneSetupData->gameplayModifiers->get_notesUniformScale();
 
             // if we don't want to change hitbox sizes, scale the cuttable hitboxes to make them proper size
             if (!globalConfig.get_alsoChangeHitboxes())
@@ -403,7 +405,8 @@ namespace Qosmetics::Notes
 
         if (globalConfig.get_overrideNoteSize())
         {
-            noteCubeTransform->get_gameObject()->AddComponent<Qosmetics::Notes::BasicNoteScaler*>();
+            auto noteScaler = noteCubeTransform->get_gameObject()->AddComponent<Qosmetics::Notes::BasicNoteScaler*>();
+            noteScaler->notesUniformScale = _gameplayCoreSceneSetupData->gameplayModifiers->get_notesUniformScale();
 
             // if we don't want to change hitbox sizes, scale the cuttable hitboxes to make them proper size
             if (!globalConfig.get_alsoChangeHitboxes())
@@ -546,7 +549,10 @@ namespace Qosmetics::Notes
         }
 
         if (globalConfig.get_overrideNoteSize())
-            noteCubeTransform->get_gameObject()->AddComponent<Qosmetics::Notes::BasicNoteScaler*>();
+        {
+            auto noteScaler = noteCubeTransform->get_gameObject()->AddComponent<Qosmetics::Notes::BasicNoteScaler*>();
+            noteScaler->notesUniformScale = _gameplayCoreSceneSetupData->gameplayModifiers->get_notesUniformScale();
+        }
 
         return original;
     }
@@ -617,7 +623,10 @@ namespace Qosmetics::Notes
         }
 
         if (globalConfig.get_overrideNoteSize())
-            noteCubeTransform->get_gameObject()->AddComponent<Qosmetics::Notes::BasicNoteScaler*>();
+        {
+            auto noteScaler = noteCubeTransform->get_gameObject()->AddComponent<Qosmetics::Notes::BasicNoteScaler*>();
+            noteScaler->notesUniformScale = _gameplayCoreSceneSetupData->gameplayModifiers->get_notesUniformScale();
+        }
 
         return original;
     }
@@ -688,7 +697,10 @@ namespace Qosmetics::Notes
         }
 
         if (globalConfig.get_overrideNoteSize())
-            noteCubeTransform->get_gameObject()->AddComponent<Qosmetics::Notes::BasicNoteScaler*>();
+        {
+            auto noteScaler = noteCubeTransform->get_gameObject()->AddComponent<Qosmetics::Notes::BasicNoteScaler*>();
+            noteScaler->notesUniformScale = _gameplayCoreSceneSetupData->gameplayModifiers->get_notesUniformScale();
+        }
 
         return original;
     }


### PR DESCRIPTION
Theoretically implements a fix for note hitboxes being malformed when small notes modifier is selected